### PR TITLE
Add mouse resize to hyprland config

### DIFF
--- a/internal/config/hyprland.go
+++ b/internal/config/hyprland.go
@@ -262,6 +262,14 @@ bind = $mod, bracketright, layoutmsg, preselect r
 bind = $mod, R, layoutmsg, togglesplit
 bind = $mod CTRL, F, resizeactive, exact 100%
 
+# === Move/resize windows with mainMod + LMB/RMB and dragging ===
+bindmd = $mod, mouse:272, Move window, movewindow
+bindmd = $mod, mouse:273, Resize window, resizewindow
+
+# === Move/resize windows with mainMod + LMB/RMB and dragging ===
+bindd = $mod, code:20, Expand window left, resizeactive, -100 0
+bindd = $mod, code:21, Shrink window left, resizeactive, 100 0
+
 # === Manual Sizing ===
 binde = $mod, minus, resizeactive, -10% 0
 binde = $mod, equal, resizeactive, 10% 0


### PR DESCRIPTION
This is to add  keybinds to the hyprland config to drag windows and resize them with right click. Not sure if Niri has something similar to this. I am not familiar with their config file. 
