### PR TITLE
fix(opensuse): correct libsecret runtime dependency for dankcalendar-git

### DIFF
--- a/distro/opensuse/dankcalendar-git.spec
+++ b/distro/opensuse/dankcalendar-git.spec
@@ -13,7 +13,7 @@ BuildRequires:  golang >= 1.25
 BuildRequires:  systemd-rpm-macros
 
 Requires:       quickshell-git
-Requires:       libsecret1
+Requires:       libsecret-1-0
 Requires:       libQt6Quick6
 
 %description


### PR DESCRIPTION
## Problem

Installing `dankcalendar-git` on openSUSE Tumbleweed fails to resolve dependencies:

```
Problem: 1: nothing provides 'libsecret1' needed by the to be installed
dankcalendar-git-0.1.2+git19.d88f1b16-1.1.x86_64
```

`distro/opensuse/dankcalendar-git.spec` requires `libsecret1`, which is not a valid package name on any distribution. On openSUSE the Secret Service library is shipped as `libsecret-1-0`:

```
$ zypper info libsecret-1-0
Name           : libsecret-1-0
Version        : 0.21.7-2.2
```

## Fix

Change the runtime dependency to `libsecret-1-0`. This matches the package's own Debian declaration in `distro/debian/dankcalendar-git/debian/control`, which already uses the correct `libsecret-1-0` name.

```diff
-Requires:       libsecret1
+Requires:       libsecret-1-0
```

Fixes AvengeMedia/DankMaterialShell#2650