### PR TITLE
fix(packaging): declare Conflicts/Replaces libcpptrace1 in OBS cpptrace metadata

### DIFF
--- a/distro/debian/cpptrace/debian/control
+++ b/distro/debian/cpptrace/debian/control
@@ -8,6 +8,8 @@ Homepage: <https://github.com/jeremy-rifkin/cpptrace>
 
 Package: libcpptrace
 Architecture: any
+Conflicts: libcpptrace1
+Replaces: libcpptrace1
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Simple, portable, and drop-in C++ stacktrace library
  cpptrace is an easy to use C++ stacktrace library providing a

--- a/distro/fedora/cpptrace/cpptrace.spec
+++ b/distro/fedora/cpptrace/cpptrace.spec
@@ -13,6 +13,8 @@ BuildRequires:  ninja-build
 BuildRequires:  libdwarf-devel
 BuildRequires:  libunwind-devel
 BuildRequires:  pkgconf
+Conflicts:     libcpptrace1
+Obsoletes:     libcpptrace1
 
 %description
 cpptrace is an easy to use C++ stacktrace library providing a 

--- a/distro/opensuse/cpptrace.spec
+++ b/distro/opensuse/cpptrace.spec
@@ -13,6 +13,8 @@ BuildRequires:  ninja
 BuildRequires:  libdwarf-devel
 BuildRequires:  libunwind-devel
 BuildRequires:  pkgconf
+Conflicts:      libcpptrace1
+Obsoletes:      libcpptrace1
 
 %description
 cpptrace is an easy to use C++ stacktrace library providing a 

--- a/distro/ubuntu/cpptrace/debian/control
+++ b/distro/ubuntu/cpptrace/debian/control
@@ -8,6 +8,8 @@ Homepage: <https://github.com/jeremy-rifkin/cpptrace>
 
 Package: libcpptrace
 Architecture: any
+Conflicts: libcpptrace1
+Replaces: libcpptrace1
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Simple, portable, and drop-in C++ stacktrace library
  cpptrace is an easy to use C++ stacktrace library providing a


### PR DESCRIPTION
# Declare `libcpptrace1` conflict in OBS `cpptrace` packaging metadata

## TL;DR

Add `Conflicts:` (and `Replaces:` on Debian-family, `Obsoletes:` on RPM) for
the distro-native `libcpptrace1` package to the OBS-built `cpptrace` package
metadata across all four supported distribution families. Without the dual
declaration, dpkg/rpm refuse the upgrade on systems that already ship a
distro-native `libcpptrace1`, which blocks `dms`/`quickshell` installation for
every Debian-forky (and equivalent) operator.

## Why

The OBS fork of `cpptrace` (from
[`jeremy-rifkin/cpptrace`](https://github.com/jeremy-rifkin/cpptrace)) ships
the same `.so` filename (`libcpptrace.so.<version>`) as the distro-native
`libcpptrace1` package that ships in Debian main (1.0.4-2 in forky/testing),
Ubuntu main (jammy, noble), Fedora, and openSUSE. When a user with the distro
package installed upgrades to the OBS build, the package manager refuses to
overwrite a file owned by another package:

```
dpkg: error processing archive .../libcpptrace_1.0.4.db9_amd64.deb (--unpack):
 trying to overwrite '/usr/lib/x86_64-linux-gnu/libcpptrace.so.1.0.4',
 which is also in package libcpptrace1 (1.0.4-2)
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

The OBS `cpptrace` package metadata does not declare a `Conflicts:`/`Replaces:`
field for `libcpptrace1`. This means every B2B operator deploying DMS on a
fresh `forky/testing` workstation must:

1. Notice the dpkg error,
2. Manually `apt remove libcpptrace1`, then
3. Re-run the installer.

That's a fleet-rollout blocker.

## Why both `Conflicts` AND `Replaces` (not one or the other)

`Conflicts` and `Replaces` are **two distinct declarations with different
semantic roles** in the Debian package manager pipeline. Either one alone
is insufficient:

| Field | Role (per Debian Policy Manual) | Effect if used alone |
|---|---|---|
| `Conflicts: libcpptrace1` | Mutual-exclusion marker (Policy §7.4). Tells apt that the two packages **cannot be installed simultaneously**. | Apt flags `libcpptrace1` for removal in the transaction, but dpkg's unpack-phase file-overwrite protection can still fire when processing the new `.deb` against the existing file ownership in `/var/lib/dpkg/status`. |
| `Replaces: libcpptrace1` | File-ownership transfer marker (Policy §7.6). Authorizes dpkg to **take over files** of the listed package during unpack. | Dpkg overwrites the file, but `libcpptrace1` remains in `/var/lib/dpkg/status` with no owned files — a "zombie package" that the manager still considers installed. |
| `Conflicts` + `Replaces` (this PR) | Combined "Package Takeover" — Apt removes the old package **and** dpkg is authorized to overwrite files atomically. | Clean, idempotent swap. The standard pattern for total substitution in Debian packaging. |

References for reviewers:

- [Debian Policy Manual §7.4 — Conflicts](https://www.debian.org/doc/debian-policy/ch-relationships.html#s-conflicts):
  *"`Conflicts` declares an absolute conflict: no installed package may
  satisfy the relationship."*
- [Debian Policy Manual §7.6 — Replaces](https://www.debian.org/doc/debian-policy/ch-relationships.html#s-replaces):
  *"`Replaces` declares that this package's files replace files in the
  listed package."*
- [Debian Developer's Reference §6.3.4 — Replacing entire packages](https://www.debian.org/doc/developers-reference/best-pkging-practices.html#replacing-entire-packages)

## Why `Obsoletes` AND `Conflicts` on RPM

The RPM ecosystem (`dnf`/`zypper`) has a slightly different model:

- **`Obsoletes: libcpptrace1`** is the RPM equivalent of Debian's
  `Conflicts` + `Replaces` combined: it tells the package manager that this
  package **replaces** the listed one, and the obsoleted package is
  auto-removed during the transaction. Reference: [RPM Packaging Guide —
  Obsoletes](https://rpm-packaging-guide.github.io/#obsoletes).

- **`Conflicts: libcpptrace1`** is technically redundant under normal
  `dnf install cpptrace` flows, since `Obsoletes` already implies auto-removal.
  We add it anyway as a **defensive shield** for the edge case where an
  operator installs directly via `rpm -ivh cpptrace.rpm`, bypassing `dnf`'s
  higher-level transaction logic. `rpm -ivh` does not consult Obsoletes in
  the same transactional way; Conflicts is the belt-and-suspenders that makes
  the refusal loud and unambiguous. Cost: 1 line; benefit: parity of error
  semantics across `rpm`/`dnf`/`zypper` invocation paths.

## Scope boundary

This PR does NOT:

- Change the OBS rebuild pipeline or CI configuration (`.obs/workflows/_service`,
  `distro/obs-project.conf`).
- Change `cpptrace`'s source tarball, build flags, or runtime behavior.
- Address other DMS packaging collisions (handled in separate PRs/issues).
- Touch the application repo (`AvengeMedia/DankMaterialShell`).
- Touch distro-specific overrides in `distro/obs-project.conf:Ignore`/`Prefer`.

## Changes

Four atomic commits, one per distribution family. Total diff: **8 insertions**
across **4 files**. Each commit is single-file, single-concern to facilitate
cherry-picking by family if the maintainers want to merge incrementally.

### `distro/debian/cpptrace/debian/control`

```diff
 Package: libcpptrace
 Architecture: any
+Conflicts: libcpptrace1
+Replaces: libcpptrace1
 Depends: ${shlibs:Depends}, ${misc:Depends}
```

### `distro/ubuntu/cpptrace/debian/control`

Same pattern as Debian (Ubuntu is Debian-derived; same dpkg/apt stack).

### `distro/opensuse/cpptrace.spec`

```diff
 BuildRequires:  pkgconf
+Conflicts:      libcpptrace1
+Obsoletes:      libcpptrace1

 %description
```

### `distro/fedora/cpptrace/cpptrace.spec`

Same pattern as openSUSE (Fedora and openSUSE both use RPM; same field
semantics).

## Validation (read-only, post-fix)

After the OBS rebuild with the new metadata:

```bash
# Debian/Ubuntu — apt simulation (no disk writes):
apt-get -s install libcpptrace=1.0.4.db9
# Expected post-fix output:
#   The following packages will be REMOVED:
#     libcpptrace1
#   The following NEW packages will be installed:
#     libcpptrace

# Real install:
sudo apt-get install libcpptrace=1.0.4.db9

# RPM-family:
sudo dnf install cpptrace   # Fedora
sudo zypper install cpptrace  # openSUSE
```

No new build steps are introduced. No CI workflow changes.

## Adjacency to #5 (closed)

This PR is structurally similar to
[`fix(opensuse): correct libsecret runtime dependency for
dankcalendar-git`](https://github.com/AvengeMedia/DankLinux/issues/5) — both
correct distro-specific metadata in the DankLinux packaging repo. Each is a
single-file, single-concern fix.

## Refs

- Upstream issue:
  [`AvengeMedia/DankMaterialShell#2773`](https://github.com/AvengeMedia/DankMaterialShell/issues/2773)
- This repo (`AvengeMedia/DankLinux`) is the canonical venue for this fix.
- Debian Policy Manual §7.4 (Conflicts), §7.6 (Replaces)
- RPM Packaging Guide — Obsoletes tag
- Local install reproduction is also the gist
  [`louzt/1c85044d5090d19223c3f5edf426a19e`](https://gist.github.com/louzt/1c85044d5090d19223c3f5edf426a19e).

## License

This PR is provided under the same MIT terms as the parent
[`AvengeMedia/DankLinux`](https://github.com/AvengeMedia/DankLinux) repository.